### PR TITLE
fix: hdmitx: reboot by edid panic [1/1]

### DIFF
--- a/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_edid.c
+++ b/drivers/amlogic/media/vout/hdmitx/hdmi_tx_20/hdmi_tx_edid.c
@@ -1747,7 +1747,7 @@ static int hdmitx_edid_block_parse(struct hdmitx_dev *hdev,
 	prxcap->native_VIC = 0xff;
 
 	Edid_Y420CMDB_Reset(&(hdev->hdmi_info));
-	if (end > 126)
+	if (end > 127)
 		return 0;
 	for (offset = 4 ; offset < end ; ) {
 		tag = blockbuf[offset] >> 5;


### PR DESCRIPTION
Increase EDID length block limit to 127.
Some extension block do report 0x7F length.