### PR TITLE
amdolby_vision: Metadata Level 5 - handling for OSD

### DIFF
--- a/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
+++ b/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
@@ -291,10 +291,11 @@ MODULE_PARM_DESC(dolby_vision_use_source_meta_levels, "\n dolby_vision_use_sourc
 // 0 - discard if present
 // 1 - keep with source values or inject with zero values if missing
 // 2 - keep with zero values or inject with zero values if missing
-// 3 - subtitles off: keep with source values or inject with zero values if missing
-//     subtitles on:  keep with zero values or inject with zero values if missing
-
-static unsigned int dolby_vision_keep_source_meta_level_5 = 2;
+// 3 - OSD and subtitles off: keep with source values or inject with zero values if missing
+//     OSD or subtitles on:  keep with zero values or inject with zero values if missing
+// 4 - OSD off: keep with source values or inject with zero values if missing
+//     OSD on:  keep with zero values or inject with zero values if missing
+static unsigned int dolby_vision_keep_source_meta_level_5 = 3;
 module_param(dolby_vision_keep_source_meta_level_5, uint, 0664);
 MODULE_PARM_DESC(dolby_vision_keep_source_meta_level_5, "\n dolby_vision_keep_source_meta_level_5\n");
 
@@ -303,6 +304,18 @@ MODULE_PARM_DESC(dolby_vision_keep_source_meta_level_5, "\n dolby_vision_keep_so
 static unsigned int dolby_vision_keep_source_meta_level_6 = 0;
 module_param(dolby_vision_keep_source_meta_level_6, uint, 0664);
 MODULE_PARM_DESC(dolby_vision_keep_source_meta_level_6, "\n dolby_vision_keep_source_meta_level_6\n");
+
+// 0 (integer value for false) - xbmc OSD OFF
+// 1 (integer value for true) - xbmc OSD ON
+static unsigned int aml_dv_keep_source_md_level_5_xbmc_osd_status = 0;
+module_param(aml_dv_keep_source_md_level_5_xbmc_osd_status, uint, 0664);
+MODULE_PARM_DESC(aml_dv_keep_source_md_level_5_xbmc_osd_status, "\n aml_dv_keep_source_md_level_5_xbmc_osd_status\n");
+
+// 0 (integer value for false) - xbmc Video Player Debug OFF
+// 1 (integer value for true) - xbmc Video Player Debug ON
+static unsigned int aml_dv_keep_source_md_level_5_xbmc_playdebug_status = 0;
+module_param(aml_dv_keep_source_md_level_5_xbmc_playdebug_status, uint, 0664);
+MODULE_PARM_DESC(aml_dv_keep_source_md_level_5_xbmc_playdebug_status, "\n aml_dv_keep_source_md_level_5_xbmc_playdebug_status\n");
 
 // 0 (integer value for false) - subtitles OFF
 // 1 (integer value for true) - subtitles ON
@@ -5845,8 +5858,9 @@ static inline void source_meta_copy(
 
 		// Choose what to copy
 		if (((level != 5) && (level != 6)) ||
-		    ((level == 5) && ((dolby_vision_keep_source_meta_level_5 == 1) ||
-			 			      ((dolby_vision_keep_source_meta_level_5 == 3) && !dolby_vision_subtitles))) ||
+		    ((level == 5) && (dolby_vision_keep_source_meta_level_5 == 1)) ||
+			((level == 5) && (dolby_vision_keep_source_meta_level_5 == 3) && !aml_dv_keep_source_md_level_5_xbmc_osd_status && !dolby_vision_subtitles) ||
+			((level == 5) && (dolby_vision_keep_source_meta_level_5 == 4) && !aml_dv_keep_source_md_level_5_xbmc_osd_status) ||
 		    ((level == 6) && (dolby_vision_keep_source_meta_level_6 == 1)))
 		{
 			// If Level is 6 and did not see a level 5 then inject one first.
@@ -5865,8 +5879,9 @@ static inline void source_meta_copy(
 			remaining_space -= level_size;
 			num_levels++;
 		}
-		else if ((level == 5) && ((dolby_vision_keep_source_meta_level_5 == 2) ||
-				 				  ((dolby_vision_keep_source_meta_level_5 == 3) && dolby_vision_subtitles)))
+		else if (((level == 5) && (dolby_vision_keep_source_meta_level_5 == 2)) ||
+				 ((level == 5) && (dolby_vision_keep_source_meta_level_5 == 3) && (aml_dv_keep_source_md_level_5_xbmc_osd_status || dolby_vision_subtitles)) ||
+				 ((level == 5) && (dolby_vision_keep_source_meta_level_5 == 4) && aml_dv_keep_source_md_level_5_xbmc_osd_status))
 		{
 			if (level_size != LEVEL_5_LENGTH) {
 				pr_err("Invalid metadata: Level 5 size mismatch (%zu)\n", level_size);


### PR DESCRIPTION
This PR includes the OSD portion of the DV MD Level 5 “auto feature”. Native xbmc/kodi OSD GUI Window handling functionality is used (no new GUI Windows handling needed) and the appropriate class structures/methods are used by one function in - GUIWindowFullScreen.cpp. This function (aml_dv_md_level_5_xbmc_osd_status()) is then inserted on all trigger points in the same file that would capture the OSD changes. A variable (aml_dv_keep_source_md_level_5_xbmc_osd_status) is defined as a module_param to capure the OSD change (showing or not showing on screen). The only OSD item that does not follow the xbmc/kodi  GUI Window normal handling is the Player Debug information that is shown on the top of the screen. To address this omission the Player Debug OSD is captured at its triggering method and it works as intended. Another variable (aml_dv_keep_source_md_level_5_xbmc_playdebug_status) is also defined as a module_param to capure this OSD change for the Player Debug information (showing or not showing on screen).
As a note, there is a bug with xbmc/kodi with the “HOME” screen that in one specific case shows on the screen without being identified as “active” with the video fullscreen video still showing as active even though it is not. If you “back” into the HOME screen while playing a movie the bug is not triggered but if you directly select the HOME screen while playing a movie the bug is triggered. This is not a problem since the black bars does not cover any part of the home screen that cannot be accessed. I added an additional clause condition on the if statement specifically for this bug but it did not resolve it. I left it in since if this bug is at least partially corrected in the future this clause could potentially help.
