### PR TITLE
Remediate Bug for VSVDB DV-LL Max Lum higher than Source Max Lum

### DIFF
--- a/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
+++ b/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
@@ -631,7 +631,8 @@ static void dolby_vision_addr(void)
 		CORE3_BASE = 0x3600;
 	}
 }
-static u32 addr_map(u32 adr)
+
+static inline u32 addr_map(u32 adr)
 {
 
 	if (adr & CORE1_OFFSET)
@@ -648,37 +649,34 @@ static u32 addr_map(u32 adr)
 	return adr;
 }
 
-static u32 VSYNC_RD_DV_REG(u32 adr)
+static inline u32 VSYNC_RD_DV_REG(u32 adr)
 {
 	adr = addr_map(adr);
 	return VSYNC_RD_MPEG_REG(adr);
 }
 
-static int VSYNC_WR_DV_REG(u32 adr, u32 val)
+static inline void VSYNC_WR_DV_REG(u32 adr, u32 val)
 {
 	adr = addr_map(adr);
 	VSYNC_WR_MPEG_REG(adr, val);
-	return 0;
 }
 
-static int VSYNC_WR_DV_REG_BITS(u32 adr, u32 val, u32 start, u32 len)
+static inline void VSYNC_WR_DV_REG_BITS(u32 adr, u32 val, u32 start, u32 len)
 {
 	adr = addr_map(adr);
 	VSYNC_WR_MPEG_REG_BITS(adr, val, start, len);
-	return 0;
 }
 
-static u32 READ_VPP_DV_REG(u32 adr)
+static inline u32 READ_VPP_DV_REG(u32 adr)
 {
 	adr = addr_map(adr);
 	return READ_VPP_REG(adr);
 }
 
-static int WRITE_VPP_DV_REG(u32 adr, const u32 val)
+static inline void WRITE_VPP_DV_REG(u32 adr, const u32 val)
 {
 	adr = addr_map(adr);
 	WRITE_VPP_REG(adr, val);
-	return 0;
 }
 
 static unsigned int amdolby_vision_poll(struct file *file, poll_table *wait)

--- a/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
+++ b/drivers/amlogic/media/enhancement/amdolby_vision/amdolby_vision.c
@@ -554,47 +554,47 @@ static u32 debug_bypass_vpp_pq;
 static bool module_installed;
 
 #define MAX_PARAM   8
-static bool is_meson_gxm(void)
+static inline bool is_meson_gxm(void)
 {
 	return (dv_meson_dev.cpu_id == _CPU_MAJOR_ID_GXM);
 }
 
-static bool is_meson_g12(void)
+static inline bool is_meson_g12(void)
 {
 	return (dv_meson_dev.cpu_id == _CPU_MAJOR_ID_G12);
 }
 
-static bool is_meson_sc2(void)
+static inline bool is_meson_sc2(void)
 {
 	return (dv_meson_dev.cpu_id == _CPU_MAJOR_ID_SC2);
 }
 
-static bool is_meson_box(void)
+static inline bool is_meson_box(void)
 {
 	return (is_meson_gxm() || is_meson_g12() || is_meson_sc2());
 }
 
-static bool is_meson_txlx(void)
+static inline bool is_meson_txlx(void)
 {
 	return (dv_meson_dev.cpu_id == _CPU_MAJOR_ID_TXLX);
 }
 
-static bool is_meson_txlx_stbmode(void)
+static inline bool is_meson_txlx_stbmode(void)
 {
 	return is_meson_txlx();
 }
 
-static bool is_meson_tm2(void)
+static inline bool is_meson_tm2(void)
 {
 	return ((dv_meson_dev.cpu_id == _CPU_MAJOR_ID_TM2) || (dv_meson_dev.cpu_id == _CPU_MAJOR_ID_TM2_REVB));
 }
 
-static bool is_meson_tm2_stbmode(void)
+static inline bool is_meson_tm2_stbmode(void)
 {
 	return is_meson_tm2();
 }
 
-static int is_graphics_output_off(void)
+static inline int is_graphics_output_off(void)
 {
 	if (is_meson_g12() || is_meson_tm2_stbmode() || is_meson_sc2())
 		return !(READ_VPP_REG(OSD1_BLEND_SRC_CTRL) & (0xf << 8)) &&


### PR DESCRIPTION
@cpm-code , ok, so I rewrote the code to Remediate Bug for VSVDB DV-LL Max Lum higher than Source Max Lum.

I re-wrote it using bit operators/operands so the code is smaller and faster.

Now the code will remediate not only if a VSVDB is modified by the user but also if it is read from the display.

I do not have a VSVDB V1 or V0 device to test these versions, so I restricted my code to V2. The code includes a bit operator/operand to read the VSVDB version so it ease to added code for V1 and V0 to the same function. From you previous post it seems that you have a LG E8 which I think is a VSVDB V1 device so you could use it to develop and test the V1 code. Not sure if you have a V0 device or not to develop the V0 code.

I found out that early on the code md_buf and orig_meta_buffer has the original (valid) source max pq value but it is modified somewhere in the pipeline. By the time you reverse the code to combo_buf  it is already altered to match the VSVDB max lum value. I did not trace the code to find out where it is modified but if you can do that and fix this modification as your did for L1 then this could be a potential path to fix the root cause of this problem.

In any case, by the time either md_buf or orig_meta_buffer is used on the amdolby_vision.c code it is already to late to update the VSVDB based on the current code workflow. To use these values you would have to delay the processing of the VSVDB but, at least for me, it already takes to long for the movie to start playing after you click to play the movie, so I did not want to delay any further. So I used the xbmc side to get the source max pq value. I did code the CSysfsPath command on a function in the AMLUtils.cpp file as you requested. The invocation of this function is still at the BitstreamConverter.cpp since that was the fastest way that I found to get this value to amdolby_vision.c.

I also took a look at the changes you are making and noticed that you are not using the "dolby_vision_ll_policy == DOLBY_VISION_LL_RGB444" flag to trigger the correction. Although there are very few devices that uses DOLBY_VISION_LL_RGB444 they do exist. For example I have a Lumagen video processor and the latest firmware updates allows players to use this capability which by the way besides the CoreELEC the Magnetar is a player that can do DOLBY_VISION_LL_RGB444.

Also, as I mentioned previously, you probably do not want to change LLDV VSVDB min luminance besides having PQ 0 or PQ 20 (with PQ 20 you need to correct the black floor). Any other value will create black level problems for LLDV, if the value is small you will only see with a scope but with larger min lum values you will be able to see with your naked eyes. Just my 2 cents.
